### PR TITLE
refactor: simplify code of getting window from webContents

### DIFF
--- a/shell/browser/extensions.js
+++ b/shell/browser/extensions.js
@@ -21,14 +21,13 @@ const getParentWindowOfTab = tab => {
   switch (tab.getType()) {
     case 'window':
       return BrowserWindow.fromWebContents(tab)
-    case 'browserView': {
-      const browserView = BrowserView.fromWebContents(tab)
-      return BrowserWindow.getAllWindows().find(win =>
-        win.getBrowserViews().includes(browserView)
-      )
-    }
+    case 'browserView':
+    case 'webview':
+      return tab.getOwnerBrowserWindow()
   }
 }
+
+exports.getParentWindowOfTab = getParentWindowOfTab;
 
 const sendToHosts = (eventName, ...args) => {
   extensionHosts.forEach(host => {
@@ -166,7 +165,7 @@ class TabsAPI extends EventEmitter {
   }
 
   createTabDetails(tab) {
-    const win = BrowserWindow.fromWebContents(tab)
+    const win = getParentWindowOfTab(tab)
     const isMainFrame = win ? win.webContents === tab : false
     const [width = 0, height = 0] = win ? win.getSize() : []
 

--- a/shell/browser/main.js
+++ b/shell/browser/main.js
@@ -13,7 +13,8 @@ const {
   extensions,
   createPopup,
   observeTab,
-  observeExtensionHost
+  observeExtensionHost,
+  getParentWindowOfTab
 } = require('./extensions.js')
 
 let webuiExtensionId
@@ -123,20 +124,7 @@ class Browser {
   }
 
   getWindowFromWebContents(webContents) {
-    let window
-    switch (webContents.getType()) {
-      case 'window':
-        window = BrowserWindow.fromWebContents(webContents)
-        break
-      case 'browserView': {
-        const browserView = BrowserView.fromWebContents(webContents)
-        window = BrowserWindow.getAllWindows().find(win =>
-          win.getBrowserViews().includes(browserView)
-        )
-        break
-      }
-    }
-
+    const window = getParentWindowOfTab(webContents);
     return window ? this.windows.find(win => win.id === window.id) : null
   }
 
@@ -213,11 +201,9 @@ class Browser {
     })
 
     extensions.tabs.on('create-tab-info', (tabInfo, webContents) => {
-      const win = this.getWindowFromWebContents(webContents)
       const selectedId = win.tabs.selected ? win.tabs.selected.id : -1
       Object.assign(tabInfo, {
         active: tabInfo.id === selectedId,
-        windowId: win.id,
         windowType: 'normal' // TODO
       })
     })

--- a/shell/browser/main.js
+++ b/shell/browser/main.js
@@ -201,6 +201,7 @@ class Browser {
     })
 
     extensions.tabs.on('create-tab-info', (tabInfo, webContents) => {
+      const win = this.getWindowFromWebContents(webContents)
       const selectedId = win.tabs.selected ? win.tabs.selected.id : -1
       Object.assign(tabInfo, {
         active: tabInfo.id === selectedId,


### PR DESCRIPTION
In Electron, there's a hidden `webContents.getOwnerBrowserWindow` method.