### PR TITLE
Better handling for varying extension popup sizes and behavior

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -88,6 +88,17 @@ export class PopupView {
 
     if (this.destroyed) return
 
+    const hasChildNodes = await this.browserWindow!.webContents.executeJavaScript(
+      `((${() => {
+        return document.body.hasChildNodes();
+      }})())`
+    )
+
+    if (!hasChildNodes) {
+      this.destroy()
+      return
+    }
+
     if (!this.usingPreferredSize) {
       // Set large initial size to avoid overflow
       this.setSize({ width: PopupView.BOUNDS.maxWidth, height: PopupView.BOUNDS.maxHeight })


### PR DESCRIPTION
Some extensions have a popup html file which is otherwise only used to spawn a script, e.g.:
https://chrome.google.com/webstore/detail/boomerang-for-gmail/mdanidgdpmkimeiiojknlnekblgmpdll

You can see the contents of popup.html in that extension is just a <script> element and nothing else. This results in electron-browser-shell triggering the action as well as opening up a completely large-ish blank popup window that does nothing. This behavior is unlike Chrome, in which the same extension will fire the action but there is no visible popup window.

This change checks to see if the body element has any nodes, text, or non-text elements, and will kill the window if it does not contain content. This makes it more consistent with how Chrome behaves with the same extension (where no visible popup window is shown if it contains no content).

I'm unsure if this is the right way to do this, and I suspect the best way to check would be to see how Chrome determines if a popup window should not be made visible or not but I'm unaware of where that code may be in the Chrome codebase.

I also had a slight concern that because this happens so early in the process, could this kill the window before its containing <script> is run?