### PR TITLE
added temporary removeExtension method as it currently has no alterna…

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -158,7 +158,8 @@ export class BrowserActionAPI {
     return action
   }
 
-  private removeActions(session: Electron.Session, extensionId: string) {
+  // TODO: Make private after backporting extension registry events
+  removeActions(session: Electron.Session, extensionId: string) {
     const sessionActions = this.getSessionActions(session)
 
     if (sessionActions.has(extensionId)) {

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -137,4 +137,14 @@ export class Extensions extends EventEmitter {
   addExtension(extension: Electron.Extension) {
     this.browserAction.processExtension(this.store.session, extension)
   }
+
+  /**
+   * Remove extensions from the list of visible extension action buttons.
+   *
+   * This is a temporary API which will go away soon after extension registry
+   * events have been backported from Electron v12.
+   */
+  removeExtension(extension: Electron.Extension) {
+    this.browserAction.removeActions(this.store.session, extension.id)
+  }
 }


### PR DESCRIPTION
Currently, there is no method to remove an extension publically.
Until the TODOs can be met, this functionality is needed to allow unloading extensions.

---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
