### PR TITLE
fix events for extension-unloaded for electron 12 stable

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/context-menus.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/context-menus.ts
@@ -60,9 +60,9 @@ export class ContextMenusAPI {
     store.handle('contextMenus.remove', this.remove)
     store.handle('contextMenus.removeAll', this.removeAll)
 
-    this.store.session.on('extension-unloaded' as any, (event, extensionId) => {
-      if (this.menus.has(extensionId)) {
-        this.menus.delete(extensionId)
+    this.store.session.on('extension-unloaded' as any, (event, extension) => {
+      if (this.menus.has(extension.id)) {
+        this.menus.delete(extension.id)
       }
     })
   }

--- a/packages/electron-chrome-extensions/src/browser/api/context-menus.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/context-menus.ts
@@ -60,7 +60,8 @@ export class ContextMenusAPI {
     store.handle('contextMenus.remove', this.remove)
     store.handle('contextMenus.removeAll', this.removeAll)
 
-    this.store.session.on('extension-unloaded' as any, (event, extension) => {
+    // TODO: remove 'any' when project is upgraded to Electron 12
+    this.store.session.on('extension-unloaded' as any, (event, extension: any) => {
       if (this.menus.has(extension.id)) {
         this.menus.delete(extension.id)
       }

--- a/packages/electron-chrome-extensions/src/browser/api/notifications.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/notifications.ts
@@ -55,9 +55,9 @@ export class NotificationsAPI {
     store.handle('notifications.getPermissionLevel', this.getPermissionLevel)
     store.handle('notifications.update', this.update)
 
-    this.store.session.on('extension-unloaded' as any, (event, extensionId) => {
+    this.store.session.on('extension-unloaded' as any, (event, extension) => {
       for (const [key, notification] of this.registry) {
-        if (key.startsWith(extensionId)) {
+        if (key.startsWith(extension.id)) {
           notification.close()
         }
       }

--- a/packages/electron-chrome-extensions/src/browser/api/notifications.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/notifications.ts
@@ -55,7 +55,8 @@ export class NotificationsAPI {
     store.handle('notifications.getPermissionLevel', this.getPermissionLevel)
     store.handle('notifications.update', this.update)
 
-    this.store.session.on('extension-unloaded' as any, (event, extension) => {
+    // TODO: remove 'any' when project is upgraded to Electron 12
+    this.store.session.on('extension-unloaded' as any, (event, extension: any) => {
       for (const [key, notification] of this.registry) {
         if (key.startsWith(extension.id)) {
           notification.close()


### PR DESCRIPTION
extension-unloaded event is sending an Extension object rather than an extensionId: https://github.com/electron/electron/blob/master/docs/api/session.md

---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.