### PR TITLE
browser action icons improvement:

### DIFF
--- a/packages/electron-chrome-extensions/spec/chrome-browserAction-spec.ts
+++ b/packages/electron-chrome-extensions/spec/chrome-browserAction-spec.ts
@@ -108,11 +108,20 @@ describe('chrome.browserAction', () => {
     ]
 
     for (const { method, detail, value } of props) {
-      it(`sets and gets ${detail}`, async () => {
+      it(`sets and gets '${detail}'`, async () => {
         const newValue = value || uuid()
         await browser.exec(`browserAction.set${method}`, { [detail]: newValue })
         const result = await browser.exec(`browserAction.get${method}`)
         expect(result).to.equal(newValue)
+      })
+
+      it(`restores initial values for '${detail}'`, async () => {
+        const newValue = value || uuid()
+        const initial = await browser.exec(`browserAction.get${method}`)
+        await browser.exec(`browserAction.set${method}`, { [detail]: newValue })
+        await browser.exec(`browserAction.set${method}`, { [detail]: null })
+        const result = await browser.exec(`browserAction.get${method}`)
+        expect(result).to.equal(initial)
       })
     }
   })

--- a/packages/electron-chrome-extensions/spec/fixtures/rpc/manifest.json
+++ b/packages/electron-chrome-extensions/spec/fixtures/rpc/manifest.json
@@ -1,7 +1,9 @@
 {
   "name": "chrome-rpc",
   "version": "1.0",
-  "browser_action": {},
+  "browser_action": {
+    "default_title": "RPC"
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/packages/electron-chrome-extensions/src/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser-action.ts
@@ -115,12 +115,12 @@ export const injectBrowserAction = () => {
         const style = document.createElement('style')
         style.textContent = `
 button {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 80%;
+  background-size: 70%;
   border: none;
   border-radius: 4px;
   padding: 0;
@@ -134,9 +134,8 @@ button:hover {
 
 .badge {
   box-sizing: border-box;
-  max-width: 100%;
   height: 12px;
-  padding: 0 4px;
+  padding: 0 2px;
   border-radius: 2px;
   position: absolute;
   bottom: 0;
@@ -144,7 +143,7 @@ button:hover {
   pointer-events: none;
   line-height: 1.2;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 400;
   overflow: hidden;
   white-space: nowrap;
 }`

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -68,13 +68,20 @@ export class BrowserActionAPI {
       const senderSession = sender.session
       const action = this.getAction(senderSession, extension.id)
 
-      if (tabId) {
-        const tabAction = action.tabs[tabId] || (action.tabs[tabId] = {})
-        Object.assign(tabAction, valueObj)
+      if (propName === 'icon' && !value) {
+        debug(`resetting icon to manifest default`)
+        // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon#parameters
+        // reprocess extension (which will reset icon)
+        this.processExtension(senderSession, extension)
       } else {
-        // TODO: need to handle case where prop is set to undefined and
-        // revert the value to its default
-        Object.assign(action, valueObj)
+        if (tabId) {
+          const tabAction = action.tabs[tabId] || (action.tabs[tabId] = {})
+          Object.assign(tabAction, valueObj)
+        } else {
+          // TODO: need to handle case where prop is set to undefined and
+          // revert the value to its default
+          Object.assign(action, valueObj)
+        }
       }
 
       this.onUpdate()


### PR DESCRIPTION
- browserAction.setIcon(undefined|null||{}) was unsetting the icon, causing icons to stop rendering. We instead will reprocess the extension, which will reset the extension icon to manifest default per documentation
- slight improvements to badge rendering, which can now support a few additional characters of text such as 'BETA' without clipping it off
---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.