### PR TITLE
Handle edge cases where when creating non-extension windows ..

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -341,11 +341,11 @@ export class TabsAPI {
 
     const activeTab = this.store.getActiveTabFromWebContents(tab)
     const activeChanged = activeTab?.id !== tabId
-    if (!activeChanged) return
+    if (!activeChanged) {
+      this.store.setActiveTab(tab)
+    }
 
     const win = this.store.tabToWindow.get(tab)
-
-    this.store.setActiveTab(tab)
 
     // invalidate cache since 'active' has changed
     this.store.tabDetailsCache.forEach((tabInfo, cacheTabId) => {


### PR DESCRIPTION
Handle edge cases where when creating non-extension windows and webviews and using addTab on them, onActivated never reaches clearing cache putting browserActions in limbo until a round of focus change are hit.


