### PR TITLE
Funnel new-window requests into tabs.create facility

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -245,6 +245,7 @@ export class BrowserActionAPI {
         parent: win,
         url: popupUrl,
         anchorRect,
+        store: this.store,
       })
 
       debug(`opened popup: ${popupUrl}`)

--- a/packages/electron-chrome-extensions/src/browser/impl.ts
+++ b/packages/electron-chrome-extensions/src/browser/impl.ts
@@ -14,5 +14,5 @@ export interface ChromeExtensionImpl {
 
   createWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow>
   removeWindow?(window: Electron.BrowserWindow): void
-  newWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow>
+  newWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow | null>
 }

--- a/packages/electron-chrome-extensions/src/browser/impl.ts
+++ b/packages/electron-chrome-extensions/src/browser/impl.ts
@@ -14,4 +14,5 @@ export interface ChromeExtensionImpl {
 
   createWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow>
   removeWindow?(window: Electron.BrowserWindow): void
+  newWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow>
 }

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -80,7 +80,7 @@ export class PopupView {
 
     this.browserWindow.webContents.on('new-window', (event, url) => {
       event.preventDefault()
-      return this.store.createTab({url: url, active:true})
+      return this.store.newWindow({url: url})
     });
 
     this.load(opts.url)

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, Session } from 'electron'
+import {ExtensionStore} from "./store";
 
 const debug = require('debug')('electron-chrome-extensions:popup')
 
@@ -15,6 +16,7 @@ interface PopupViewOptions {
   parent: BrowserWindow
   url: string
   anchorRect: PopupAnchorRect
+  store: ExtensionStore
 }
 
 export class PopupView {
@@ -30,6 +32,7 @@ export class PopupView {
   browserWindow?: BrowserWindow
   parent?: BrowserWindow
   extensionId: string
+  store: ExtensionStore
 
   private anchorRect: PopupAnchorRect
   private destroyed: boolean = false
@@ -41,6 +44,7 @@ export class PopupView {
     this.parent = opts.parent
     this.extensionId = opts.extensionId
     this.anchorRect = opts.anchorRect
+    this.store = opts.store
 
     this.browserWindow = new BrowserWindow({
       show: false,
@@ -73,6 +77,11 @@ export class PopupView {
     this.browserWindow.on('blur', this.maybeClose)
     this.browserWindow.on('closed', this.destroy)
     this.parent.once('closed', this.destroy)
+
+    this.browserWindow.webContents.on('new-window', (event, url) => {
+      event.preventDefault()
+      return this.store.createTab({url: url, active:true})
+    });
 
     this.load(opts.url)
   }

--- a/packages/electron-chrome-extensions/src/browser/store.ts
+++ b/packages/electron-chrome-extensions/src/browser/store.ts
@@ -122,6 +122,18 @@ export class ExtensionStore extends EventEmitter {
     }
   }
 
+  async newWindow(details: chrome.windows.CreateData) {
+    if (typeof this.impl.newWindow !== 'function') {
+      throw new Error('newWindow is not implemented')
+    }
+
+    const win = await this.impl.newWindow(details)
+
+    this.addWindow(win)
+
+    return win
+  }
+
   getTabById(tabId: number) {
     return Array.from(this.tabs).find((tab) => !tab.isDestroyed() && tab.id === tabId)
   }

--- a/packages/electron-chrome-extensions/src/browser/store.ts
+++ b/packages/electron-chrome-extensions/src/browser/store.ts
@@ -129,7 +129,9 @@ export class ExtensionStore extends EventEmitter {
 
     const win = await this.impl.newWindow(details)
 
-    this.addWindow(win)
+    if (win) {
+      this.addWindow(win)
+    }
 
     return win
   }


### PR DESCRIPTION
There are cases when an extension is opening a tab that isn't using the tabs.create facility or any other API for opening a window/tab. This in turn causes issues where there seems to be a new BrowserWindow created with similar properties as this PopupView. Once this PopupView closes, so does the new BrowserWindow.

So instead, the proposed solution is to funnel any requests for a new-window ba a BrowserAction into the tabs.create facility. This allows the implementer to continue handling the new window as they desire via the createTab handler.

For an example of an extension that does this odd behavior:
Grammarly's Log In or Sign Up buttons when BrowserAction is initiated from **specifically** a Google Doc (docs.google.com) document. Grammarly has a different popup depending on where you activate its BrowserAction. docs.google.com documents have a special beta docs popup, and its buttons do not issue tabs.create API calls, which is unlike Grammarly's standard popup which does use those facilities.

---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
