### PR TITLE
feat: use pattern matching for url in tabs.query

### DIFF
--- a/packages/electron-chrome-extensions/spec/chrome-tabs-spec.ts
+++ b/packages/electron-chrome-extensions/spec/chrome-tabs-spec.ts
@@ -45,6 +45,14 @@ describe('chrome.tabs', () => {
       expect(result[0].windowId).to.be.equal(browser.window.id)
     })
 
+    it('gets the tab using pattern match', async () => {
+      const result = await browser.crx.exec('tabs.query', { url: "http://*.*.*.*" })
+      expect(result).to.be.an('array')
+      expect(result).to.be.length(1)
+      expect(result[0].id).to.be.equal(browser.window.webContents.id)
+      expect(result[0].windowId).to.be.equal(browser.window.id)
+    })
+
     it('gets the active tab of multiple windows', async () => {
       const secondWindow = new BrowserWindow({
         show: false,

--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from 'electron'
 import { ExtensionContext } from '../context'
 import { ExtensionEvent } from '../router'
-import { TabContents } from './common'
+import { matchesPattern, TabContents } from './common'
 import { WindowsAPI } from './windows'
 
 const debug = require('debug')('electron-chrome-extensions:tabs')
@@ -180,7 +180,13 @@ export class TabsAPI {
         // if (isSet(info.lastFocusedWindow)) return false
         if (isSet(info.status) && info.status !== tab.status) return false
         if (isSet(info.title) && info.title !== tab.title) return false // TODO: pattern match
-        if (isSet(info.url) && info.url !== tab.url) return false // TODO: match URL pattern
+        if (isSet(info.url) && info.url && tab.url) {
+          if(typeof(info.url) === "string" && !matchesPattern(info.url, tab.url)) {
+            return false;
+          } else if(Array.isArray(info.url) && info.url.every((url) => tab.url && !matchesPattern(url, tab.url))) {
+            return false;
+          }
+        }
         if (isSet(info.windowId)) {
           if (info.windowId === TabsAPI.WINDOW_ID_CURRENT) {
             if (this.ctx.store.lastFocusedWindowId !== tab.windowId) return false


### PR DESCRIPTION
Use matchesPattern function to use patternMatching to compare URLs in the tabs.query() function.
Also adds corresponding tests to verify this change.
Fixes #42 

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
