### PR TITLE
FIX: Check if tab is active before activation

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -67,7 +67,8 @@ export class TabsAPI {
     })
 
     this.onCreated(tabId)
-    this.onActivated(tabId)
+    const activeTab = this.ctx.store.getActiveTabFromWebContents(tab)
+    if (activeTab?.id === tabId) this.onActivated(tabId);
 
     debug(`Observing tab[${tabId}][${tab.getType()}] ${tab.getURL()}`)
   }


### PR DESCRIPTION
When extensions.addTab() is called, it emits an event that triggers the observeTab function. This function finally calls this.onActivated(), activating the tab, even if the user did not call select on it. In this fix, I check if the tab is active before calling the this.onActivated() function. See [this issue](https://github.com/skyebrowser/skye/issues/13#issuecomment-986523225) for more info.

---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
