### PR TITLE
Early Draft Discussion: Delegate popup creation + action handling

### DIFF
--- a/packages/electron-chrome-extensions/package.json
+++ b/packages/electron-chrome-extensions/package.json
@@ -41,10 +41,9 @@
     "typescript": "^4.0.2",
     "uuid": "^8.3.1",
     "walkdir": "^0.4.1",
-    "webpack": "^4.44.1",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },
-  "peerDependencies": {},
   "babel": {
     "presets": [
       [

--- a/packages/electron-chrome-extensions/src/browser/impl.ts
+++ b/packages/electron-chrome-extensions/src/browser/impl.ts
@@ -1,3 +1,6 @@
+import {BrowserActionState} from "./api/browser-action"
+import {PopupViewOptions} from "./popup"
+
 /** App-specific implementation details for extensions. */
 export interface ChromeExtensionImpl {
   createTab?(
@@ -14,4 +17,8 @@ export interface ChromeExtensionImpl {
 
   createWindow?(details: chrome.windows.CreateData): Promise<Electron.BrowserWindow>
   removeWindow?(window: Electron.BrowserWindow): void
+
+  createPopup?(details: PopupViewOptions): void
+
+  onBrowserActionUpdate?(details: BrowserActionState): void
 }

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import path from 'path'
 import { promises as fs } from 'fs'
 
-import { BrowserActionAPI } from './api/browser-action'
+import {ActivateDetails, BrowserActionAPI} from './api/browser-action'
 import { TabsAPI } from './api/tabs'
 import { WindowsAPI } from './api/windows'
 import { WebNavigationAPI } from './api/web-navigation'
@@ -128,6 +128,10 @@ export class ElectronChromeExtensions extends EventEmitter {
     if (this.ctx.store.tabs.has(tab)) {
       this.api.tabs.onActivated(tab.id)
     }
+  }
+
+  activateExtension(tab: Electron.WebContents, details: ActivateDetails) {
+    this.api.browserAction.activate({sender: tab}, details)
   }
 
   /**

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -9,12 +9,13 @@ export interface PopupAnchorRect {
   height: number
 }
 
-interface PopupViewOptions {
+export interface PopupViewOptions {
   extensionId: string
   session: Session
   parent: BrowserWindow
   url: string
   anchorRect: PopupAnchorRect
+  tabId: number
 }
 
 export class PopupView {

--- a/packages/electron-chrome-extensions/src/browser/store.ts
+++ b/packages/electron-chrome-extensions/src/browser/store.ts
@@ -1,8 +1,10 @@
 import { BrowserWindow, webContents } from 'electron'
 import { EventEmitter } from 'events'
+import {BrowserActionState} from "./api/browser-action"
 import { ContextMenuType } from './api/common'
 import { ChromeExtensionImpl } from './impl'
 import { ExtensionEvent } from './router'
+import {PopupView, PopupViewOptions} from "./popup"
 
 const debug = require('debug')('electron-chrome-extensions:store')
 
@@ -186,6 +188,23 @@ export class ExtensionStore extends EventEmitter {
       if (typeof this.impl.selectTab === 'function') {
         this.impl.selectTab(tab, win)
       }
+    }
+  }
+
+  // TODO: this probably doesn't belong in store.ts
+  createPopup(opts: PopupViewOptions){
+    if(this.impl.createPopup){
+      return this.impl.createPopup(opts)
+    } else {
+      return new PopupView(opts)
+    }
+
+  }
+
+  // TODO: this probably doesn't belong in store.ts
+  onBrowserActionUpdate(opts: BrowserActionState){
+    if(this.impl.onBrowserActionUpdate){
+      this.impl.onBrowserActionUpdate(opts)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,7 +4658,7 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.44.1:
+webpack@^4.46.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
This is a super early draft of a few changes to the popup/browserActions that helped me integrate it a bit. Still need to figure out what to do with a few stale pieces now. 

Major changes:

- Added `getStateWithIcons` that returns the state with the base64 URI for the icon of the avatar. This gives a good workdaround for https://github.com/samuelmaddock/electron-browser-shell/issues/41
- Added `ChromeExtensionImpl.createPopup?(details: PopupViewOptions): void` . This way you can handle making your own popup instead of using the PopupView
- Added `ChromeExtensionImpl.onBrowserActionUpdate?(details: BrowserActionState): void`. This way you can watch for icon/callback changes and construct your own UI without using the <browser-action-list/> customElement
- Added `ElectronChromeExtensions.activateExtension` to manually trigger click/contextmenu if you created your own elements. 
  
Before I cleanup the code I want to make sure I'm on the right path. What are your thoughts on this? 


---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
