### PR TITLE
Fix other session icons

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -1,14 +1,14 @@
-import { Menu, MenuItem, protocol, nativeImage, app } from 'electron'
-import { ExtensionContext } from '../context'
-import { PopupView } from '../popup'
-import { ExtensionEvent } from '../router'
+import {app, Menu, MenuItem, nativeImage, protocol} from 'electron'
+import {ExtensionContext} from '../context'
+import {PopupView} from '../popup'
+import {ExtensionEvent} from '../router'
 import {
-  getExtensionUrl,
   getExtensionManifest,
+  getExtensionUrl,
   getIconPath,
-  resolveExtensionPath,
   matchSize,
   ResizeType,
+  resolveExtensionPath,
 } from './common'
 
 const debug = require('debug')('electron-chrome-extensions:browserAction')
@@ -192,6 +192,10 @@ export class BrowserActionAPI {
     })
 
     session.protocol.registerBufferProtocol('crx', this.handleCrxRequest)
+  }
+
+  public setupProtocol(session:Electron.Session){
+    return session.protocol.registerBufferProtocol('crx', this.handleCrxRequest)
   }
 
   private handleCrxRequest = (

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -91,6 +91,11 @@ export class ElectronChromeExtensions extends EventEmitter {
     this.prependPreload()
   }
 
+  public setupProtocol(session:Electron.Session){
+    this.api.browserAction.setupProtocol(session)
+  }
+
+
   private async prependPreload() {
     const { session } = this.ctx
     let preloads = session.getPreloads()

--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -408,6 +408,7 @@ export const injectExtensionAPIs = () => {
             ...base,
             WINDOW_ID_NONE: -1,
             WINDOW_ID_CURRENT: -2,
+            getCurrent:invokeExtension('windows.getCurrent'),
             get: invokeExtension('windows.get'),
             getLastFocused: invokeExtension('windows.getLastFocused'),
             getAll: invokeExtension('windows.getAll'),


### PR DESCRIPTION
thank for your project.
when i use browser-action to display extension icons.
it can't show in a default-session window.
so i added a method called setupProtocol in browser/index.ts
`  public setupProtocol(session:Electron.Session){
    this.api.browserAction.setupProtocol(session)
  }`
after that
i added a public method in  api/browser-action.ts
such like this 
`  public setupProtocol(session:Electron.Session){
    return session.protocol.registerBufferProtocol('crx', this.handleCrxRequest)
  }
`
so ,we can register the protocol in other sessions.

and i also added an api to getCurrentWindow
---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
