### PR TITLE
add support for opening relative URLs from popups, fixes #73

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -143,6 +143,9 @@ export class TabsAPI {
   }
 
   private async create(event: ExtensionEvent, details: chrome.tabs.CreateProperties = {}) {
+    // make URL absolute
+    details.url = new URL(details.url, event.sender.getURL()).href;
+    
     const tab = await this.ctx.store.createTab(details)
     const tabDetails = this.getTabDetails(tab)
     if (details.active) {

--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -144,8 +144,9 @@ export class TabsAPI {
 
   private async create(event: ExtensionEvent, details: chrome.tabs.CreateProperties = {}) {
     // make URL absolute
-    details.url = new URL(details.url, event.sender.getURL()).href;
-    
+    if (details.url) {
+      details.url = new URL(details.url, event.sender.getURL()).href;
+    }
     const tab = await this.ctx.store.createTab(details)
     const tabDetails = this.getTabDetails(tab)
     if (details.active) {

--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -143,13 +143,17 @@ export class TabsAPI {
   }
 
   private async create(event: ExtensionEvent, details: chrome.tabs.CreateProperties = {}) {
+    const parsedDetails = {
+      ...details,
+    };
     // make URL absolute
     if (details.url) {
-      details.url = new URL(details.url, event.sender.getURL()).href;
+      parsedDetails.url = new URL(details.url, event.extension.url).href;
     }
-    const tab = await this.ctx.store.createTab(details)
+
+    const tab = await this.ctx.store.createTab(parsedDetails)
     const tabDetails = this.getTabDetails(tab)
-    if (details.active) {
+    if (parsedDetails.active) {
       queueMicrotask(() => this.onActivated(tab.id))
     }
     return tabDetails
@@ -237,12 +241,21 @@ export class TabsAPI {
 
     const props = updateProperties
 
+    const parsedProps = {
+      ...props,
+    };
+    // make URL absolute
+    if (props.url) {
+      parsedProps.url = new URL(props.url, event.extension.url).href;
+    }
+
+
     // TODO: validate URL, prevent 'javascript:'
-    if (props.url) await tab.loadURL(props.url)
+    if (parsedProps.url) await tab.loadURL(parsedProps.url)
 
-    if (typeof props.muted === 'boolean') tab.setAudioMuted(props.muted)
+    if (typeof parsedProps.muted === 'boolean') tab.setAudioMuted(parsedProps.muted)
 
-    if (props.active) this.onActivated(tabId)
+    if (parsedProps.active) this.onActivated(tabId)
 
     this.onUpdated(tabId)
 


### PR DESCRIPTION
<!-- Please include a description of changes. -->
This fixes the issue mentioned in #73 and uses the senders URL to make the to-open URL absolute without changing any already fully specified URLS

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
