### PR TITLE
[electron-chrome-extensions] handle a tab of null explicitly as no tab in executeScript

### DIFF
--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -335,7 +335,7 @@ export const injectExtensionAPIs = () => {
               // C++, but it doesn't support implicit execution in the active
               // tab. To handle this, we need to get the active tab ID and
               // pass it into the C++ implementation ourselves.
-              if (typeof arg1 === 'object') {
+              if (typeof arg1 === 'object' || arg1 === null) {
                 api.query(
                   { active: true, windowId: chrome.windows.WINDOW_ID_CURRENT },
                   ([activeTab]: chrome.tabs.Tab[]) => {

--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -336,10 +336,12 @@ export const injectExtensionAPIs = () => {
               // tab. To handle this, we need to get the active tab ID and
               // pass it into the C++ implementation ourselves.
               if (typeof arg1 === 'object' || arg1 === null) {
+                const passArg1 = arg1 !== null ? arg1 : arg2;
+                const passArg2 = arg1 !== null ? arg2 : arg3;
                 api.query(
                   { active: true, windowId: chrome.windows.WINDOW_ID_CURRENT },
                   ([activeTab]: chrome.tabs.Tab[]) => {
-                    api.executeScript(activeTab.id, arg1, arg2)
+                    api.executeScript(activeTab.id, passArg1, passArg2)
                   }
                 )
               } else {


### PR DESCRIPTION
Some extensions use `null` as the value for the tabID, and Chromium handles this as if it is not there. This change updates the `electron-browser-shell` implementation such that the behavior is the same. 

This enables support for the [snapfont](https://chrome.google.com/webstore/detail/snapfont-preview-fonts-on/nkddaimdokgdjkekmdakdaojkfaghomj?hl=en) extension, which uses `tab.executeScript(null, {file: ....})` to add support for webComponents. Currently this is ignored, causing the content script to fail.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
