### PR TITLE
[electron-chrome-extensions] use the app store ID instead of the generated ID

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -409,7 +409,7 @@ export class BrowserActionAPI {
       label: extension.name,
       click: () => {
         const homePageUrl =
-          manifest.homepage_url || `https://chrome.google.com/webstore/detail/${extension.id}`
+          manifest.homepage_url || `https://chrome.google.com/webstore/detail/${extension.path.split("/").at(-1)}`
         this.ctx.store.createTab({ url: homePageUrl })
       },
     })


### PR DESCRIPTION
The context menu of a browser action links to the homepage and if that's missing, it links to the Chrome store. In Electron, `extension.id` is not always the same as the chrome store id, though they look like similar strings. The install path does contain the correct chrome store ID, so this patch changes it to use this.

You can test this with [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh).

Once merged this fixes #80.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
