### PR TITLE
[electron-chrome-extensions] Turn sourcemaps for preload file off

### DIFF
--- a/packages/electron-chrome-extensions/webpack.config.js
+++ b/packages/electron-chrome-extensions/webpack.config.js
@@ -25,6 +25,7 @@ const preload = {
   ...webpackBase,
 
   target: 'electron-preload',
+  devtool: false,
 
   entry: {
     preload: './src/preload.ts'


### PR DESCRIPTION
<!-- Please include a description of changes. -->
The build config adds sourcemaps to all files, including the preload file. However in some configurations because the preload file comes from node modules, the sourcemap is not available and devtools then try to get `preload.js.map` from the top level domain of the current webcontents, resulting in a warning in the console. 

This turns the preload sourcemap off to make that warning go away.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.