### PR TITLE
docs: added note to run yarn build before yarn start in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ A minimal, tabbed web browser with support for Chrome extensions—built on Elec
 git clone git@github.com:samuelmaddock/electron-browser-shell.git
 cd electron-browser-shell
 
-# Install and launch the browser
+# Install, build the necessary packages and launch the browser
 yarn
+yarn build
 yarn start
 ```
 


### PR DESCRIPTION
**Description**
Updated the README to clarify that users need to run `yarn build` before `yarn start`. This resolves the issue where running `yarn start` alone results in an error related to the `electron-chrome-web-store` package not being found.

**Changes Made**
- Added `yarn build` step in the **Usage** section.

**Why This is Needed**
Users attempting to run `yarn start` without building the packages encounter errors. This update ensures that the setup instructions are clear and prevents potential confusion.


✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
