### PR TITLE
feat: browser action list positioning

### DIFF
--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -219,7 +219,7 @@ To enable the element on a webpage, you must define a preload script which injec
 - `partition` string (optional) - The `Electron.Session` partition which extensions are loaded in. Defaults to the session in which `<browser-action-list>` lives.
 - `tab` string (optional) - The tab's `Electron.WebContents` ID to use for displaying
   the relevant browser action state. Defaults to the active tab of the current browser window.
-- `alignment` string (optional) - The alignment of the `<browser-action-list>` in relation to the browser window - used to inform the positioning of popups. Defaults to `top right`. Use any assortment of `top`, `bottom`, `left`, and `right` to describe where the list is positioned.
+- `popup` string (optional) - Where the popup window should show in relation to the `<browser-action-list>` element. Defaults to `bottom left`. Use any assortment of `top`, `bottom`, `left`, and `right` to describe where the popup should be opened.
 
 #### Browser action example
 
@@ -252,8 +252,8 @@ Add the `<browser-action-list>` element with attributes appropriate for your app
 <!-- Show actions for custom session and a specific tab of current window. -->
 <browser-action-list partition="persist:custom" tab="1"></browser-action-list>
 
-<!-- If your extensions are in the top left of the browser then popups will be show to the right -->
-<browser-action-list alignment="top left"></browser-action-list>
+<!-- If you show extensions in the bottom left of the browser then you can align the popups to the top right of the component -->
+<browser-action-list alignment="top right"></browser-action-list>
 ```
 
 ##### Custom CSS

--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -219,7 +219,7 @@ To enable the element on a webpage, you must define a preload script which injec
 - `partition` string (optional) - The `Electron.Session` partition which extensions are loaded in. Defaults to the session in which `<browser-action-list>` lives.
 - `tab` string (optional) - The tab's `Electron.WebContents` ID to use for displaying
   the relevant browser action state. Defaults to the active tab of the current browser window.
-- `popup` string (optional) - Where the popup window should show in relation to the `<browser-action-list>` element. Defaults to `bottom left`. Use any assortment of `top`, `bottom`, `left`, and `right` to describe where the popup should be opened.
+- `alignment` string (optional) - How the popup window should be aligned relative to the extension action. Defaults to `bottom left`. Use any assortment of `top`, `bottom`, `left`, and `right`.
 
 #### Browser action example
 
@@ -252,7 +252,8 @@ Add the `<browser-action-list>` element with attributes appropriate for your app
 <!-- Show actions for custom session and a specific tab of current window. -->
 <browser-action-list partition="persist:custom" tab="1"></browser-action-list>
 
-<!-- If you show extensions in the bottom left of the browser then you can align the popups to the top right of the component -->
+<!-- If extensions are displayed in the bottom left of your browser UI, then
+     you can align the popup to the top right of the extension action. -->
 <browser-action-list alignment="top right"></browser-action-list>
 ```
 

--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -219,6 +219,7 @@ To enable the element on a webpage, you must define a preload script which injec
 - `partition` string (optional) - The `Electron.Session` partition which extensions are loaded in. Defaults to the session in which `<browser-action-list>` lives.
 - `tab` string (optional) - The tab's `Electron.WebContents` ID to use for displaying
   the relevant browser action state. Defaults to the active tab of the current browser window.
+- `alignment` string (optional) - The alignment of the `<browser-action-list>` in relation to the browser window - used to inform the positioning of popups. Defaults to `top right`. Use any assortment of `top`, `bottom`, `left`, and `right` to describe where the list is positioned.
 
 #### Browser action example
 
@@ -250,6 +251,9 @@ Add the `<browser-action-list>` element with attributes appropriate for your app
 
 <!-- Show actions for custom session and a specific tab of current window. -->
 <browser-action-list partition="persist:custom" tab="1"></browser-action-list>
+
+<!-- If your extensions are in the top left of the browser then popups will be show to the right -->
+<browser-action-list alignment="top left"></browser-action-list>
 ```
 
 ##### Custom CSS

--- a/packages/electron-chrome-extensions/src/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser-action.ts
@@ -160,7 +160,6 @@ export const injectBrowserAction = () => {
 
       private activate(event: Event) {
         const rect = this.getBoundingClientRect()
-        console.log('Thing has been clicked', this)
 
         browserAction.activate(this.partition || DEFAULT_PARTITION, {
           eventType: event.type,

--- a/packages/electron-chrome-extensions/src/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser-action.ts
@@ -19,6 +19,7 @@ export const injectBrowserAction = () => {
     extensionId: string
     tabId: number
     anchorRect: { x: number; y: number; width: number; height: number }
+    alignment?: string
   }
 
   const __browserAction__ = {
@@ -115,8 +116,16 @@ export const injectBrowserAction = () => {
         }
       }
 
+      get alignment(): string {
+        return this.getAttribute('alignment') || ''
+      }
+
+      set alignment(alignment: string) {
+        this.setAttribute('alignment', alignment)
+      }
+
       static get observedAttributes() {
-        return ['id', 'tab', 'partition']
+        return ['id', 'tab', 'partition', 'alignment']
       }
 
       constructor() {
@@ -151,11 +160,13 @@ export const injectBrowserAction = () => {
 
       private activate(event: Event) {
         const rect = this.getBoundingClientRect()
+        console.log('Thing has been clicked', this)
 
         browserAction.activate(this.partition || DEFAULT_PARTITION, {
           eventType: event.type,
           extensionId: this.id,
           tabId: this.tab,
+          alignment: this.alignment,
           anchorRect: {
             x: rect.left,
             y: rect.top,
@@ -280,8 +291,16 @@ export const injectBrowserAction = () => {
         }
       }
 
+      get alignment(): string {
+        return this.getAttribute('alignment') || ''
+      }
+
+      set alignment(alignment: string) {
+        this.setAttribute('alignment', alignment)
+      }
+
       static get observedAttributes() {
-        return ['tab', 'partition']
+        return ['tab', 'partition', 'alignment']
       }
 
       constructor() {
@@ -413,12 +432,14 @@ export const injectBrowserAction = () => {
             }) as BrowserActionElement
             node.id = action.id
             node.className = 'action'
+            ;(node as any).alignment = this.alignment
             ;(node as any).part = 'action'
             browserActionNode = node
             this.shadowRoot?.appendChild(browserActionNode)
           }
 
           if (this.partition) browserActionNode.partition = this.partition
+          if (this.alignment) browserActionNode.alignment = this.alignment
           browserActionNode.tab = tabId
         }
 

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -34,6 +34,7 @@ interface ActivateDetails {
   extensionId: string
   tabId: number
   anchorRect: { x: number; y: number; width: number; height: number }
+  alignment?: string
 }
 
 const getBrowserActionDefaults = (extension: Electron.Extension): ExtensionAction | undefined => {
@@ -390,7 +391,7 @@ export class BrowserActionAPI {
   }
 
   private activateClick(details: ActivateDetails) {
-    const { extensionId, tabId, anchorRect } = details
+    const { extensionId, tabId, anchorRect, alignment } = details
 
     if (this.popup) {
       const toggleExtension = !this.popup.isDestroyed() && this.popup.extensionId === extensionId
@@ -422,6 +423,7 @@ export class BrowserActionAPI {
         parent: win,
         url: popupUrl,
         anchorRect,
+        alignment,
       })
 
       d(`opened popup: ${popupUrl}`)

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -207,8 +207,8 @@ export class PopupView {
     let y = winBounds.y + this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING
 
     // If aligned to a differently then we need to offset the popup position
-    if (this.alignment?.includes('left')) x = winBounds.x + this.anchorRect.x
-    if (this.alignment?.includes('bottom'))
+    if (this.alignment?.includes('right')) x = winBounds.x + this.anchorRect.x
+    if (this.alignment?.includes('top'))
       y = winBounds.y - viewBounds.height + this.anchorRect.y - PopupView.POSITION_PADDING
 
     // Convert to ints

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -16,6 +16,7 @@ interface PopupViewOptions {
   parent: Electron.BaseWindow
   url: string
   anchorRect: PopupAnchorRect
+  alignment?: string
 }
 
 const supportsPreferredSize = () => {
@@ -40,6 +41,7 @@ export class PopupView {
   private anchorRect: PopupAnchorRect
   private destroyed: boolean = false
   private hidden: boolean = true
+  private alignment?: string
 
   /** Preferred size changes are only received in Electron v12+ */
   private usingPreferredSize = supportsPreferredSize()
@@ -50,6 +52,7 @@ export class PopupView {
     this.parent = opts.parent
     this.extensionId = opts.extensionId
     this.anchorRect = opts.anchorRect
+    this.alignment = opts.alignment
 
     this.browserWindow = new BrowserWindow({
       show: false,
@@ -200,9 +203,13 @@ export class PopupView {
     const winBounds = this.parent.getBounds()
     const viewBounds = this.browserWindow.getBounds()
 
-    // TODO: support more orientations than just top-right
     let x = winBounds.x + this.anchorRect.x + this.anchorRect.width - viewBounds.width
     let y = winBounds.y + this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING
+
+    // If aligned to a differently then we need to offset the popup position
+    if (this.alignment?.includes('left')) x = winBounds.x + this.anchorRect.x
+    if (this.alignment?.includes('bottom'))
+      y = winBounds.y - viewBounds.height + this.anchorRect.y - PopupView.POSITION_PADDING
 
     // Convert to ints
     x = Math.floor(x)

--- a/packages/shell/browser/ui/webui.html
+++ b/packages/shell/browser/ui/webui.html
@@ -244,7 +244,7 @@
         <div class="address-bar">
           <input id="addressurl" spellcheck="false" />
         </div>
-        <browser-action-list id="actions"></browser-action-list>
+        <browser-action-list id="actions" alignment="bottom left"></browser-action-list>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- Please include a description of changes. -->

**added:** Support for defining the position of the `<browser-action-list />` web component.

I've kept this simple as to allow a developer to define corner alignment rather than arbitrary positioning (which saw mentioned in #46).

Heres a demo of `top right` (the default) and also `bottom right` (even though I left the icons in the top left, but you should get the idea of how this is working.

https://github.com/user-attachments/assets/6646cc84-90ef-4f2a-969d-1c094302276b

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
