### PR TITLE
feat: setPartitionSessionGrabber function

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/router.ts
+++ b/packages/electron-chrome-extensions/src/browser/router.ts
@@ -45,6 +45,12 @@ interface RoutingDelegateObserver {
   removeListener(listener: EventListener, extensionId: string, eventName: string): void
 }
 
+type PartitionSessionGrabber = (partition: string) => Electron.Session
+let getSessionFromPartition: PartitionSessionGrabber = session.fromPartition
+export function setPartitionSessionGrabber(handler: PartitionSessionGrabber) {
+  getSessionFromPartition = handler
+}
+
 let gRoutingDelegate: RoutingDelegate
 
 /**
@@ -117,7 +123,7 @@ class RoutingDelegate {
     const ses =
       sessionPartition === DEFAULT_SESSION
         ? getSessionFromEvent(event)
-        : session.fromPartition(sessionPartition)
+        : getSessionFromPartition(sessionPartition)
 
     const observer = this.sessionMap.get(ses)
 

--- a/packages/electron-chrome-extensions/src/index.ts
+++ b/packages/electron-chrome-extensions/src/index.ts
@@ -1,1 +1,3 @@
 export * from './browser'
+
+export { setPartitionSessionGrabber } from './browser/router'


### PR DESCRIPTION
<!-- Please include a description of changes. -->

## Problem

When using `<browser-actions>`, you can only access other sessions with their Partition ID.

What if someone is not using partitions, but using `session.fromPath()`?

They will not be able to access other sessions via `<browser-actions>`

## Solution

A `setPartitionSessionGrabber()` function to override the default `session.getPartition()` function, which lets developers retrieve sessions using custom identifiers.

## Sample Code

```ts
import { setPartitionSessionGrabber } from "electron-chrome-extensions";

const partitionSessionGrabber = (partition: string) => {
  // custom: grab the session from the profile
  const PROFILE_PREFIX = "profile:";
  if (partition.startsWith(PROFILE_PREFIX)) {
    const profileId = partition.slice(PROFILE_PREFIX.length);
    const session = getSessionFromProfileId(profileId);
    if (session) {
      return session;
    } else {
      throw new Error(`Session not found for profile ${profileId}`);
    }
  }

  return session.fromPartition(partition);
};

setPartitionSessionGrabber(partitionSessionGrabber);
```

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
