### PR TITLE
fix: observer not being removed

### DIFF
--- a/packages/electron-chrome-extensions/src/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser-action.ts
@@ -62,6 +62,7 @@ export const injectBrowserAction = () => {
 
       if (count === 0) {
         invoke('browserAction.removeObserver', partition)
+        observerCounts.delete(partition)
       }
     },
   }


### PR DESCRIPTION
<!-- Please include a description of changes. -->

This fix ensures when you have multiple sessions, the other sessions won't stay connected.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
