### PR TITLE
Add note about requiring sandbox

### DIFF
--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -77,9 +77,9 @@ app.whenReady().then(() => {
 
   const browserWindow = new BrowserWindow({
     webPreferences: {
-      // Same session given to Extensions class
+      // Use same session given to Extensions class
       session: browserSession,
-      // required for extensions to work
+      // Required for extension preload scripts
       sandbox: true,
       // Recommended for loading remote content
       contextIsolation: true,
@@ -492,7 +492,7 @@ See [Electron's Notification tutorial](https://www.electronjs.org/docs/tutorial/
 - Usage of Electron's `webRequest` API will prevent `chrome.webRequest` listeners from being called.
 - Chrome extensions are not supported in non-persistent/incognito sessions.
 - `chrome.webNavigation.onDOMContentLoaded` is only emitted for the top frame until [support for iframes](https://github.com/electron/electron/issues/27344) is added.
-- Extensions will only work if Electrons sandbox is enabled. This is the default behavior but might be overridden by the `--no-sandbox` flag or `sandbox: false` in the `webPreferences` of a `BrowserWindow`. Check for the `--no-sandbox` flag using `ps -eaf | grep <appname>`.
+- Service worker preload scripts require Electron's sandbox to be enabled. This is the default behavior, but might be overridden by the `--no-sandbox` flag or `sandbox: false` in the `webPreferences` of a `BrowserWindow`. Check for the `--no-sandbox` flag using `ps -eaf | grep <appname>`.
 
 ## License
 


### PR DESCRIPTION
<!-- Please include a description of changes. -->

This adds a note to the electron-chrome-extension README to highlight that sandboxing is a requirement, and likewise updates the example code.

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
