### PR TITLE
add new offset attribute to browser-action-list to determine the offset

### DIFF
--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -248,6 +248,7 @@ To enable the element on a webpage, you must define a preload script which injec
 - `tab` string (optional) - The tab's `Electron.WebContents` ID to use for displaying
   the relevant browser action state. Defaults to the active tab of the current browser window.
 - `alignment` string (optional) - How the popup window should be aligned relative to the extension action. Defaults to `bottom left`. Use any assortment of `top`, `bottom`, `left`, and `right`.
+- `offset` string (optional) - How far the popup window should be positioned from the extension action in the alignments direction. Defaults to 5.
 
 #### Browser action example
 

--- a/packages/electron-chrome-extensions/src/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser-action.ts
@@ -20,6 +20,7 @@ export const injectBrowserAction = () => {
     tabId: number
     anchorRect: { x: number; y: number; width: number; height: number }
     alignment?: string
+    offset?: string
   }
 
   const __browserAction__ = {
@@ -125,8 +126,16 @@ export const injectBrowserAction = () => {
         this.setAttribute('alignment', alignment)
       }
 
+      get offset(): string {
+        return this.getAttribute('offset') || ''
+      }
+
+      set offset(offset: string) {
+        this.setAttribute('offset', offset)
+      }
+
       static get observedAttributes() {
-        return ['id', 'tab', 'partition', 'alignment']
+        return ['id', 'tab', 'partition', 'alignment', 'offset']
       }
 
       constructor() {
@@ -167,6 +176,7 @@ export const injectBrowserAction = () => {
           extensionId: this.id,
           tabId: this.tab,
           alignment: this.alignment,
+          offset: this.offset,
           anchorRect: {
             x: rect.left,
             y: rect.top,
@@ -305,8 +315,16 @@ export const injectBrowserAction = () => {
         this.setAttribute('alignment', alignment)
       }
 
+      get offset(): string {
+        return this.getAttribute('offset') || ''
+      }
+
+      set offset(offset: string) {
+        this.setAttribute('offset', offset)
+      }
+
       static get observedAttributes() {
-        return ['tab', 'partition', 'alignment']
+        return ['tab', 'partition', 'alignment', 'offset']
       }
 
       constructor() {
@@ -446,6 +464,7 @@ export const injectBrowserAction = () => {
 
           if (this.partition) browserActionNode.partition = this.partition
           if (this.alignment) browserActionNode.alignment = this.alignment
+          if (this.offset) browserActionNode.offset = this.offset
           browserActionNode.tab = tabId
         }
 

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -36,6 +36,7 @@ interface ActivateDetails {
   tabId: number
   anchorRect: { x: number; y: number; width: number; height: number }
   alignment?: string
+  offset?: string
 }
 
 const getBrowserActionDefaults = (extension: Electron.Extension): ExtensionAction | undefined => {
@@ -384,7 +385,7 @@ export class BrowserActionAPI {
   }
 
   private activateClick(details: ActivateDetails) {
-    const { extensionId, tabId, anchorRect, alignment } = details
+    const { extensionId, tabId, anchorRect, alignment, offset } = details
 
     if (this.popup) {
       const toggleExtension = !this.popup.isDestroyed() && this.popup.extensionId === extensionId
@@ -417,6 +418,7 @@ export class BrowserActionAPI {
         url: popupUrl,
         anchorRect,
         alignment,
+        offset,
       })
 
       d(`opened popup: ${popupUrl}`)

--- a/packages/electron-chrome-extensions/src/browser/popup.ts
+++ b/packages/electron-chrome-extensions/src/browser/popup.ts
@@ -18,6 +18,7 @@ interface PopupViewOptions {
   url: string
   anchorRect: PopupAnchorRect
   alignment?: string
+  offset?: string
 }
 
 const supportsPreferredSize = () => {
@@ -43,6 +44,7 @@ export class PopupView {
   private destroyed: boolean = false
   private hidden: boolean = true
   private alignment?: string
+  private offset: number
 
   /** Preferred size changes are only received in Electron v12+ */
   private usingPreferredSize = supportsPreferredSize()
@@ -54,6 +56,7 @@ export class PopupView {
     this.extensionId = opts.extensionId
     this.anchorRect = opts.anchorRect
     this.alignment = opts.alignment
+    this.offset = opts.offset ? parseInt(opts.offset) : PopupView.POSITION_PADDING
 
     this.browserWindow = new BrowserWindow({
       show: false,
@@ -205,12 +208,12 @@ export class PopupView {
     const viewBounds = this.browserWindow.getBounds()
 
     let x = winBounds.x + this.anchorRect.x + this.anchorRect.width - viewBounds.width
-    let y = winBounds.y + this.anchorRect.y + this.anchorRect.height + PopupView.POSITION_PADDING
+    let y = winBounds.y + this.anchorRect.y + this.anchorRect.height + this.offset
 
     // If aligned to a differently then we need to offset the popup position
     if (this.alignment?.includes('right')) x = winBounds.x + this.anchorRect.x
     if (this.alignment?.includes('top'))
-      y = winBounds.y - viewBounds.height + this.anchorRect.y - PopupView.POSITION_PADDING
+      y = winBounds.y - viewBounds.height + this.anchorRect.y - this.offset
 
     // Convert to ints
     x = Math.floor(x)


### PR DESCRIPTION
<!-- Please include a description of changes. -->
Linux systems don't correctly calculate the offset of elements when the WM draws the chrome. This adds an optional `offset` attribute to browser-action-list to tweak the offset of the popup to take this into account.

Fixes https://github.com/samuelmaddock/electron-browser-shell/issues/121

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
