### PR TITLE
main.js: fix middleclick

### DIFF
--- a/packages/shell/browser/main.js
+++ b/packages/shell/browser/main.js
@@ -341,7 +341,10 @@ class Browser {
             outlivesOpener: true,
             createWindow: ({ webContents: guest, webPreferences }) => {
               const win = this.getWindowFromWebContents(webContents)
-              const tab = win.tabs.create({ webContents: guest, webPreferences })
+              let opts = {};
+              if (guest != null) opts.webContents = guest;
+              if (webPreferences != null) opts.webPreferences = webPreferences;
+              const tab = win.tabs.create(opts)
               tab.loadURL(details.url)
               return tab.webContents
             },


### PR DESCRIPTION
Otherwise, webPreferences is undefined, and this gets thrown:
```js
Uncaught Exception:
Error: options.webPreferences must be an object

at new Tab
```