### PR TITLE
Fallback to default action icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "license": "GPL-3.0",
   "author": "Samuel Maddock <sam@samuelmaddock.com>",
-  "dependencies": {},
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^15.2.10",

--- a/packages/electron-chrome-extensions/package.json
+++ b/packages/electron-chrome-extensions/package.json
@@ -56,6 +56,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
     "walkdir": "^0.4.1"
-  },
-  "peerDependencies": {}
+  }
 }

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -61,6 +61,15 @@ const getBrowserActionDefaults = (extension: Electron.Extension): ExtensionActio
 
     return action
   }
+
+  // Fallback: Create action for extensions without explicit action but with icons.
+  const iconPath = getIconPath(extension);
+  if (iconPath) {
+    const action: ExtensionAction = {}
+    action.title = manifest.name;
+    action.icon = { path: iconPath };
+    return action;
+  }
 }
 
 interface ExtensionActionStore extends Partial<ExtensionAction> {

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -46,29 +46,26 @@ const getBrowserActionDefaults = (extension: Electron.Extension): ExtensionActio
       : manifest.manifest_version === 2
         ? manifest.browser_action
         : undefined
+
+  const iconPath = getIconPath(extension)
+
   if (typeof browserAction === 'object') {
     const manifestAction: chrome.runtime.ManifestAction = browserAction
-    const action: ExtensionAction = {}
-
-    action.title = manifestAction.default_title || manifest.name
-
-    const iconPath = getIconPath(extension)
-    if (iconPath) action.icon = { path: iconPath }
-
-    if (manifestAction.default_popup) {
-      action.popup = manifestAction.default_popup
+    const action: ExtensionAction = {
+      title: manifestAction.default_title || manifest.name,
+      ...(iconPath && { icon: { path: iconPath } }),
+      ...(manifestAction.default_popup && { popup: manifestAction.default_popup }),
     }
 
     return action
   }
 
-  // Fallback: Create action for extensions without explicit action but with icons.
-  const iconPath = getIconPath(extension);
+  // Fallback: Create action icon for extensions without explicit action.
   if (iconPath) {
-    const action: ExtensionAction = {}
-    action.title = manifest.name;
-    action.icon = { path: iconPath };
-    return action;
+    return {
+      title: manifest.name,
+      icon: { path: iconPath },
+    }
   }
 }
 

--- a/packages/electron-chrome-extensions/src/browser/api/identity.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/identity.ts
@@ -1,0 +1,76 @@
+import { BrowserWindow } from 'electron'
+import { ExtensionContext } from '../context'
+import { ExtensionEvent } from '../router'
+import debug from 'debug'
+
+const d = debug('electron-chrome-extensions:identity')
+
+interface WebAuthFlowDetails {
+  url: string
+  interactive?: boolean
+}
+
+export class IdentityAPI {
+  constructor(private ctx: ExtensionContext) {
+    const handle = this.ctx.router.apiHandler()
+    handle('identity.launchWebAuthFlow', this.launchWebAuthFlow.bind(this), {
+      permission: 'identity',
+    })
+  }
+
+  private launchWebAuthFlow = (
+    event: ExtensionEvent,
+    details: WebAuthFlowDetails,
+  ): Promise<string | undefined> => {
+    const extensionId = event.extension.id
+    const redirectBase = `https://${extensionId}.chromiumapp.org`
+
+    d(`launchWebAuthFlow [ext:${extensionId}, interactive:${details.interactive}]`)
+
+    return new Promise<string | undefined>((resolve, reject) => {
+      let settled = false
+
+      const win = new BrowserWindow({
+        show: details.interactive !== false,
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+        },
+      })
+
+      const settle = (result: string | undefined | Error) => {
+        if (settled) return
+        settled = true
+        if (!win.isDestroyed()) win.destroy()
+        if (result instanceof Error) {
+          reject(result)
+        } else {
+          resolve(result)
+        }
+      }
+
+      const checkUrl = (url: string): boolean => {
+        if (url.startsWith(redirectBase)) {
+          d(`captured redirect URL: ${url}`)
+          settle(url)
+          return true
+        }
+        return false
+      }
+
+      win.webContents.on('will-navigate', (e, url) => {
+        if (checkUrl(url)) e.preventDefault()
+      })
+
+      win.webContents.on('will-redirect', (e, url) => {
+        if (checkUrl(url)) e.preventDefault()
+      })
+
+      win.on('closed', () => {
+        settle(new Error('User closed the auth window'))
+      })
+
+      win.webContents.loadURL(details.url).catch(settle)
+    })
+  }
+}

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -10,6 +10,7 @@ import { WindowsAPI } from './api/windows'
 import { WebNavigationAPI } from './api/web-navigation'
 import { ExtensionStore } from './store'
 import { ContextMenusAPI } from './api/context-menus'
+import { IdentityAPI } from './api/identity'
 import { RuntimeAPI } from './api/runtime'
 import { CookiesAPI } from './api/cookies'
 import { NotificationsAPI } from './api/notifications'
@@ -125,6 +126,7 @@ export class ElectronChromeExtensions extends EventEmitter {
     contextMenus: ContextMenusAPI
     commands: CommandsAPI
     cookies: CookiesAPI
+    identity: IdentityAPI
     notifications: NotificationsAPI
     permissions: PermissionsAPI
     runtime: RuntimeAPI
@@ -162,6 +164,7 @@ export class ElectronChromeExtensions extends EventEmitter {
       contextMenus: new ContextMenusAPI(this.ctx),
       commands: new CommandsAPI(this.ctx),
       cookies: new CookiesAPI(this.ctx),
+      identity: new IdentityAPI(this.ctx),
       notifications: new NotificationsAPI(this.ctx),
       permissions: new PermissionsAPI(this.ctx),
       runtime: new RuntimeAPI(this.ctx),

--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -426,6 +426,20 @@ export const injectExtensionAPIs = () => {
         },
       },
 
+      identity: {
+        shouldInject: () => !!(manifest.permissions as string[] | undefined)?.includes('identity'),
+        factory: (base) => {
+          return {
+            ...base,
+            getRedirectURL: (path?: string) => {
+              const cleanPath = (path || '').replace(/^\//, '')
+              return `https://${extensionId}.chromiumapp.org/${cleanPath}`
+            },
+            launchWebAuthFlow: invokeExtension('identity.launchWebAuthFlow'),
+          }
+        },
+      },
+
       i18n: {
         shouldInject: () => manifest.manifest_version === 3,
         factory: (base) => {


### PR DESCRIPTION
I encountered that [GMass](https://chromewebstore.google.com/detail/gmass-powerful-mail-merge/ehomdgjhgmbidokdgicgmdiedadncbgf) extension was not showing the action icon in our implementation, and so does not in electron-browser-shell example.
This happens because electron-chrome-extensions relies on the "action" property in the extension's manifest to be present ("browser_action" in manifest V2).

And since both properties are optional (See [V3 Action](https://developer.chrome.com/docs/extensions/reference/api/action)), it would be nice to show the extension icon, just like Chrome does.

<img width="314" height="156" alt="image" src="https://github.com/user-attachments/assets/e5840d7c-f891-4954-82bd-efbb81d48631" />


With this PR, now it looks like this:

<img width="364" height="181" alt="image" src="https://github.com/user-attachments/assets/461fcaed-431a-4c0a-815a-ff875a9040c6" />

Regards!

---

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
