### PR TITLE
fix: resolve relative URLs in chrome.windows.create

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/common.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/common.ts
@@ -36,6 +36,20 @@ export const getExtensionUrl = (extension: Electron.Extension, uri: string) => {
   } catch {}
 }
 
+export const validateExtensionUrl = (url: string, extension: Electron.Extension) => {
+  try {
+    url = new URL(url, extension.url).href
+  } catch (e) {
+    throw new Error('Invalid URL')
+  }
+
+  if (url.startsWith('chrome:') || url.startsWith('javascript:')) {
+    throw new Error('Invalid URL')
+  }
+
+  return url
+}
+
 export const resolveExtensionPath = (
   extension: Electron.Extension,
   uri: string,

--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -1,26 +1,16 @@
 import { ExtensionContext } from '../context'
 import { ExtensionEvent } from '../router'
-import { getAllWindows, matchesPattern, matchesTitlePattern, TabContents } from './common'
+import {
+  getAllWindows,
+  matchesPattern,
+  matchesTitlePattern,
+  TabContents,
+  validateExtensionUrl,
+} from './common'
 import { WindowsAPI } from './windows'
 import debug from 'debug'
 
 const d = debug('electron-chrome-extensions:tabs')
-
-const validateExtensionUrl = (url: string, extension: Electron.Extension) => {
-  // Convert relative URLs to absolute if needed
-  try {
-    url = new URL(url, extension.url).href
-  } catch (e) {
-    throw new Error('Invalid URL')
-  }
-
-  // Prevent creating chrome://kill or other debug commands
-  if (url.startsWith('chrome:') || url.startsWith('javascript:')) {
-    throw new Error('Invalid URL')
-  }
-
-  return url
-}
 
 export class TabsAPI {
   static TAB_ID_NONE = -1

--- a/packages/electron-chrome-extensions/src/browser/api/windows.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/windows.ts
@@ -1,5 +1,6 @@
 import { ExtensionContext } from '../context'
 import { ExtensionEvent } from '../router'
+import { validateExtensionUrl } from './common'
 import debug from 'debug'
 
 const d = debug('electron-chrome-extensions:windows')
@@ -109,6 +110,11 @@ export class WindowsAPI {
   }
 
   private async create(event: ExtensionEvent, details: chrome.windows.CreateData) {
+    if (details.url) {
+      const urls = Array.isArray(details.url) ? details.url : [details.url]
+      const resolved = urls.map((u) => validateExtensionUrl(u, event.extension))
+      details = { ...details, url: Array.isArray(details.url) ? resolved : resolved[0] }
+    }
     const win = await this.ctx.store.createWindow(event, details)
     return this.getWindowDetails(win)
   }


### PR DESCRIPTION
<!-- Please include a description of changes. -->

Resolves relative URLs so apps can open the correct URLs.
Also aligns behavior with `packages/electron-chrome-extensions/src/browser/api/tabs.ts`

Before, createWindow implementation receives: `{ incognito: false, url: 'session-buddy.html' }`
After, createWindow implementation receives: `{ incognito: false, url: 'chrome-extension://edacconmaakjimmfgnblocblbcdcpbko/session-buddy.html' }`

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
