### PR TITLE
fix: refresh cached window tab details on read

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/windows.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/windows.ts
@@ -51,6 +51,16 @@ export class WindowsAPI {
     d(`Observing window[${windowId}]`)
   }
 
+  private createWindowTabsDetails(win: Electron.BaseWindow) {
+    return Array.from(this.ctx.store.tabs)
+      .filter((tab) => {
+        const ownerWindow = this.ctx.store.tabToWindow.get(tab)
+        return ownerWindow?.isDestroyed() ? false : ownerWindow?.id === win.id
+      })
+      .map((tab) => this.ctx.store.tabDetailsCache.get(tab.id) as chrome.tabs.Tab)
+      .filter(Boolean)
+  }
+
   private createWindowDetails(win: Electron.BaseWindow) {
     const details: Partial<chrome.windows.Window> = {
       id: win.id,
@@ -59,13 +69,7 @@ export class WindowsAPI {
       left: win.getPosition()[0],
       width: win.getSize()[0],
       height: win.getSize()[1],
-      tabs: Array.from(this.ctx.store.tabs)
-        .filter((tab) => {
-          const ownerWindow = this.ctx.store.tabToWindow.get(tab)
-          return ownerWindow?.isDestroyed() ? false : ownerWindow?.id === win.id
-        })
-        .map((tab) => this.ctx.store.tabDetailsCache.get(tab.id) as chrome.tabs.Tab)
-        .filter(Boolean),
+      tabs: this.createWindowTabsDetails(win),
       incognito: !this.ctx.session.isPersistent(),
       type: 'normal', // TODO
       state: getWindowState(win),
@@ -79,7 +83,12 @@ export class WindowsAPI {
 
   private getWindowDetails(win: Electron.BaseWindow) {
     if (this.ctx.store.windowDetailsCache.has(win.id)) {
-      return this.ctx.store.windowDetailsCache.get(win.id)
+      const cachedDetails = this.ctx.store.windowDetailsCache.get(win.id)
+      // Update the cached details with the latest tabs, otherwise it will be stale.
+      if (cachedDetails) {
+        cachedDetails.tabs = this.createWindowTabsDetails(win)
+      }
+      return cachedDetails
     }
     const details = this.createWindowDetails(win)
     return details


### PR DESCRIPTION
<!-- Please include a description of changes. -->

`chrome.windows.getAll()` and `chrome.windows.get()` was returning stale `tabs` arrays from cached window details. This caused the Session Buddy extension to not be able to find any open tabs.

This patch makes it alway regenerate the `tabs` array.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
