### PR TITLE
fix: patch chrome.runtime in place to preserve native bindings

### DIFF
--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -243,6 +243,12 @@ export const injectExtensionAPIs = () => {
       }
     }
 
+    const patchApiObject = <T extends object>(target: T | undefined, patch: object) => {
+      const api = (target || {}) as T
+      Object.defineProperties(api, Object.getOwnPropertyDescriptors(patch))
+      return api
+    }
+
     const browserActionFactory = (base: DeepPartial<typeof globalThis.chrome.browserAction>) => {
       const api = {
         ...base,
@@ -502,8 +508,7 @@ export const injectExtensionAPIs = () => {
 
       runtime: {
         factory: (base) => {
-          return {
-            ...base,
+          return patchApiObject(base, {
             connectNative: (application: string) => {
               const port = new NativePort()
               const receive = port._receive.bind(port)
@@ -516,7 +521,7 @@ export const injectExtensionAPIs = () => {
             },
             openOptionsPage: invokeExtension('runtime.openOptionsPage'),
             sendNativeMessage: invokeExtension('runtime.sendNativeMessage'),
-          }
+          })
         },
       },
 
@@ -646,13 +651,18 @@ export const injectExtensionAPIs = () => {
     Object.keys(apiDefinitions).forEach((key: any) => {
       const apiName: keyof typeof chrome = key
       const baseApi = chrome[apiName] as any
-      const api = apiDefinitions[apiName]!
+      const definition = apiDefinitions[apiName]!
 
       // Allow APIs to opt-out of being available in this context.
-      if (api.shouldInject && !api.shouldInject()) return
+      if (definition.shouldInject && !definition.shouldInject()) return
+
+      const injectedApi = definition.factory(baseApi)
+
+      // Factories can patch native-backed APIs in place to preserve identity.
+      if (baseApi && injectedApi === baseApi) return
 
       Object.defineProperty(chrome, apiName, {
-        value: api.factory(baseApi),
+        value: injectedApi,
         enumerable: true,
         configurable: true,
       })


### PR DESCRIPTION
<!-- Please include a description of changes. -->

**Summary**

This PR fixes a renderer-side regression where the extension API injection logic replaced `chrome.runtime` with a new plain object. That broke Electron’s native runtime bindings, because native dispatch still references the original `chrome.runtime` object for events like `onMessage` and `onConnect`.

The fix changes the runtime factory to patch the existing `chrome.runtime` object in place instead of redefining it. The generic API initialization path was also updated so factories that mutate an existing API object do not immediately replace it afterward.

**Why**

The previous code effectively did this:

```ts
Object.defineProperty(chrome, 'runtime', {
  value: { ...base, connectNative: ..., ... }
})
```

That preserves enumerable properties, but it does not preserve the original object identity. For native-backed APIs like `chrome.runtime`, object identity matters.

**What Changed**

- Added a small helper to patch an API object via property descriptors.
- Updated the `runtime` factory to mutate the existing `chrome.runtime` object.
- Updated API initialization so in-place patched APIs are not redefined.

**Result**

- `chrome.runtime` keeps its original native-backed identity.
- Renderer-added methods like `connectNative`, `openOptionsPage`, and `sendNativeMessage` are still exposed.
- Native event dispatch continues to work against the correct runtime object.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
